### PR TITLE
Added Spanish support, modified some en_US lines

### DIFF
--- a/resources/language/en_US.yml
+++ b/resources/language/en_US.yml
@@ -13,24 +13,24 @@ no-permission: "&cYou don't have the right permission to do this."
 arena-running: "&cThe arena is currently running!"
 arena-delete: "&cDeleted the arena &d{ARENA}."
 arena-exists: "&cThe arena with that name already exists!"
-arena-not-exist: "&cThe arena doesn't exists!"
+arena-not-exist: "&cThe arena doesn't exist!"
 arena-hibernation: "&cThe arena is currently in hibernation mode!"
 
 message-disconnected: "&6{PLAYER}&c has disconnected."
-message-left: "&6{PLAYER}&c has left the game.."
+message-left: "&6{PLAYER}&c has left the game..."
 
 arena-disabled: "&cThe arena is temporarily disabled, try again later."
-arena-crashed: "&cThe arena has crashed! Ask server owner to check server logs."
+arena-crashed: "&cThe arena has crashed! Ask the server owner to check server logs."
 arena-in-queue: "&6You are now queuing for {ARENA_NAME}, please wait."
 arena-join: "&6{PLAYER}&e has joined the match (&b{TOTAL_PLAYERS}&e/&b{MAX_SIZE}&e)"
 arena-startup: "&6Game starting in {TIME} seconds"
 arena-no-invincible: "&cYou are no longer invincible."
-arena-chest-refilled: "&eChests has been refilled!"
+arena-chest-refilled: "&eChests have been refilled!"
 arena-command-forbidden: "You cannot execute any command while in game."
-arena-moderation-on: "%prefix&aYou will now receiving all messages from the arenas."
-arena-moderation-off: "%prefix&cYou will no longer receiving messages from the arenas."
+arena-moderation-on: "%prefix&aYou will now receive all messages from the arenas."
+arena-moderation-off: "%prefix&cYou will no longer receive messages from the arenas."
 
-moderation-pre-enable: "%prefix&aYou will now receiving all messages from the arenas. Use /sw moderation to disable this option."
+moderation-pre-enable: "%prefix&aYou will now receive all messages from the arenas. Use /sw moderation to disable this option."
 
 # Arena titles and subtitles translations
 countdown-cancel-title: "&cNot enough players"
@@ -69,13 +69,13 @@ settings-arena-5: "Set Join Sign Behaviour"
 settings-arena-6: "Set Join Sign Location"
 settings-arena-7: "Setup Scoreboard"
 settings-arena-8: "Edit this world"
-settings-arena-9: "&cDelete this arena."
+settings-arena-9: "&cDelete this arena"
 
 behaviour-setup-1: "Arena settings."
 behaviour-setup-2: "&eEnable the arena?"
 behaviour-setup-3: "&eSet Invincible Timer"
 behaviour-setup-4: "&eEnable Spectator Mode?"
-behaviour-setup-5: "&eEnable team mode?"
+behaviour-setup-5: "&eEnable Team mode?"
 behaviour-setup-6: "&eStart when full?"
 
 team-setup-1: 'Setup team mode'
@@ -85,7 +85,7 @@ team-setup-4: 'Maximum teams'
 team-setup-5: 'Team colours'
 
 team-error-1: '&cTeam configuration error, must be an integer in range of 0-15 and separated by `;`'
-team-error-2: '&cYour configured team colour(s) is lesser than your maximum teams.'
+team-error-2: '&cYour configured team colour(s) is less than your maximum teams.'
 
 solo-setup-1: "Solo team setup"
 solo-setup-2: "Minimum players"
@@ -121,8 +121,8 @@ spectator-not-ingame: "&cYou are no longer in the arena."
 spectator-player-left: "&cThat player is no longer in the arena."
 
 setup-arena-1: "&5SkyWars Setup."
-setup-arena-2: "&6The name of your Arena."
-setup-arena-3: "&6Select your Arena level."
+setup-arena-2: "&6The name of your Arena"
+setup-arena-3: "&6Select your Arena level"
 setup-arena-4: "&eMaximum players"
 setup-arena-5: "&eMinimum players"
 setup-arena-6: "&7Spectator mode"
@@ -131,13 +131,13 @@ setup-arena-7: "&7Start on full"
 setup-arena-spawn-1: "Setup spawn?"
 setup-arena-spawn-2: "&aYou may need to setup arena's spawn position so system could enable the arena much faster."
 setup-arena-spawn-3: "Setup arena spawn."
-setup-arena-spawn-4: "&cSetup later."
+setup-arena-spawn-4: "&cSetup later"
 
 setup-later: "&aYou can setup this later with /sw settings"
 
-no-data: "&cThat player does not exists in the database!"
+no-data: "&cThat player does not exist in the database!"
 
-form-error-1: 'The id you have requested is invalid, unable to perform this command'
+form-error-1: 'The ID you have requested is invalid, unable to perform this command'
 
 scoreboard-button-1: "Waiting display"
 scoreboard-button-2: "In game display"
@@ -146,7 +146,7 @@ scoreboard-button-4: "Spectator display"
 scoreboard-button-5: "Exit"
 
 scoreboard-state-1: "This section will be used during waiting state."
-scoreboard-state-2: "This section will be used when the arena has started but without any teams."
+scoreboard-state-2: "This section will be used when the arena has started without any teams."
 scoreboard-state-3: "This section will be used when the game has finished."
 scoreboard-state-4: "This section will be used the player has died."
 
@@ -161,32 +161,32 @@ kit-selected: "%prefix&aYou have selected the &e{KIT_NAME}&a kit!"
 kit-no-permission: "%prefix&cYou do not have the permission to select &e{KIT_NAME}&c kit!"
 
 # Kill message
-death-message-void: "&7- &e{PLAYER} &cwere killed by void"
+death-message-void: "&7- &e{PLAYER} &cwas killed by void"
 death-message-suicide: "&7- &e{PLAYER} &cjust committed suicide."
-death-message-suffocated: "&7- &e{PLAYER} &csuffocated to death."
-death-message-burned: "&7- &e{PLAYER} &cwere burned to death."
+death-message-suffocated: "&7- &e{PLAYER} &cwas suffocated to death."
+death-message-burned: "&7- &e{PLAYER} &cwas burned to death."
 death-message-catused: "&7- &e{PLAYER} &ckilled by a cactus. Silly?"
-death-message-fall: "&7- &e{PLAYER} &chad fall from the sky."
-death-message-toasted: "&7- &e{PLAYER} &cwere toasted by lava"
-death-message-drowned: "&7- &e{PLAYER} &cwere drowned"
-death-message-nature: "&7- &e{PLAYER} &cwere killed by nature"
+death-message-fall: "&7- &e{PLAYER} &cfell from the sky."
+death-message-toasted: "&7- &e{PLAYER} &cwas toasted by lava"
+death-message-drowned: "&7- &e{PLAYER} &cwas drowned"
+death-message-nature: "&7- &e{PLAYER} &cwas killed by nature"
 death-message-explode: "&7- &e{PLAYER} &cexploded to pieces"
-death-message-magic: "&7- &e{PLAYER} &cwere killed by some kind of magic"
-death-message-unknown: "&7- &e{PLAYER} is a member of the illuminati"
-death-message: "&7- &e{PLAYER} &cwere killed by &e{KILLER}"
+death-message-magic: "&7- &e{PLAYER} &cwas killed by some kind of magic"
+death-message-unknown: "&7- &e{PLAYER} is a member of the Illuminati"
+death-message: "&7- &e{PLAYER} &cwas killed by &e{KILLER}"
 
 # Command help message
 help-main: "&cPlease use /sw help for a list of commands"
 lobby-help: "&2/sw leave &l&5»&r&f Teleport to lobby."
 random-help: "&2/sw random &l&5»&r&f Randomly teleport to an arena."
 stats-help: "&2/sw stats &l&5»&r&f Show your game status."
-reload-help: "&2/sw reload &l&5»&r&f Reload the plugin, make new start."
+reload-help: "&2/sw reload &l&5»&r&f Reload the plugin, make a new start."
 create-help: "&2/sw create &l&5»&r&f Create a new arena."
 cage-help: "&2/sw cage &l&5»&r&f Set your custom cages."
 join-help: "&2/sw join &b[Arena Name] &l&5»&r&f Join to the arena."
 settings-help: "&2/sw settings &l&5»&r&f Setup or modify the arena."
 setlobby-help: "&2/sw setlobby &l&5»&r&f Set the main lobby for the plugin."
-about-help: "&2/sw about &l&5»&r&f About and notes from author."
+about-help: "&2/sw about &l&5»&r&f About and notes from the author."
 npc-help: "&2/sw npc &l&5»&r&f Create an NPC for TopWinners."
 list-help: "&2/sw list &l&5»&r&f List all running arenas in the server."
 
@@ -212,8 +212,8 @@ cage-error-chosen: "&cYou already have bought this cage!"
 cage-chosen: "%prefix&aYou have chosen cage &e{CAGE_NAME}."
 
 economy-error: "&cThis feature is disabled due to no EconomyAPI plugin installed."
-economy-no-money: "&cYou don't have enough money to buy this"
-economy-internal: "&cCannot process your payment. Try again later"
+economy-no-money: "&cYou don't have enough money to buy this."
+economy-internal: "&cCannot process your payment. Try again later."
 
 # Panel messages
 panel-cancelled: "&cYour request has been cancelled."

--- a/resources/language/es_ES.yml
+++ b/resources/language/es_ES.yml
@@ -1,0 +1,229 @@
+###########################################################################################
+# This is a YML file. Be careful when editing. Check your edits in a YAML checker like    #
+# the one at http://yaml-online-parser.appspot.com                                        #
+###########################################################################################
+---
+# No reason to edit this
+config-version: 10
+
+low-permission: "&eHmm, algún comando nuevo, que mal que aún no esté disponible."
+no-permission: "&cNo tienes los permisos correctos para hacer esto"
+
+# Arena-Game behaviour language.
+arena-running: "&cLa arena está corriendo ahora mismo!"
+arena-delete: "&cLa arena &d{ARENA} fue borrada."
+arena-exists: "&cLa arena con ese nombre ya existe!"
+arena-not-exist: "&cLa arena no existe!"
+arena-hibernation: "&cLa arena se encuentra en modo de hibernación!"
+
+message-disconnected: "&6{PLAYER}&c se ha desconectado."
+message-left: "&6{PLAYER}&c ha dejado el juego..."
+
+arena-disabled: "&cLa arena está temporalmente deshabilitada, intenta después."
+arena-crashed: "&cLa arena se ha caído! Preguntale al dueño para que revise los registros del servidor."
+arena-in-queue: "&6Estás en la lista de espera para {ARENA_NAME}, espera por favor."
+arena-join: "&6{PLAYER}&e se ha unido al juego (&b{TOTAL_PLAYERS}&e/&b{MAX_SIZE}&e)"
+arena-startup: "&6El juego empieza en {TIME} segundos"
+arena-no-invincible: "&cYa no eres invencible."
+arena-chest-refilled: "&eLos cofres han sido rellenados!"
+arena-command-forbidden: "No puedes ejecutar ningún comando en medio del juego."
+arena-moderation-on: "%prefix&aRecibirás todos los mensajes de las arenas."
+arena-moderation-off: "%prefix&cYa no recibirás mensajes de las arenas."
+
+moderation-pre-enable: "%prefix&aRecibirás todos los mensajes de las arenas. Utiliza /sw moderation para deshabilitar esta opción."
+
+# Arena titles and subtitles translations
+countdown-cancel-title: "&cNo hay suficientes jugadores."
+countdown-cancel-subtitle: "&cLa cuenta atrás ha sido cancelada."
+countdown-starting-title: "&6Empezando en"
+countdown-starting-subtitle: ""
+countdown-started-title: "&cEmpezó el juego!"
+countdown-started-subtitle: ""
+
+died-title: "&c&lMORISTE!"
+died-subtitle: "&7Ahora eres un espectador."
+
+# Command messages, Here the messages
+arena-unavailable: "&cNo hay arenas disponibles, intenta después."
+arena-started: "&aEmpezó la arena &d{ARENA}."
+main-lobby-set: "&aEstablecida exitosamente esta ubicación como lobby de SkyWars."
+no-world: "&cLo siento, no te queda ningún mundo para crear una arena."
+command-setlobby-inarena: "&cNo puedes ejecutar este comando en una arena!"
+use-in-arena: "&cPor favor usa este comando en la arena"
+
+stats-1: "&Estadísticas de a{PLAYER}"
+stats-2: "&6Nombre: &f{DATA}"
+stats-3: "&6Matanzas: &f{DATA}"
+stats-4: "&6Muertes: &f{DATA}"
+stats-5: "&6Radio de Matanza/Muerte: &f{DATA}"
+stats-6: "&6Juegos Ganados: &f{DATA}"
+stats-7: "&6Juegos Perdidos: &f{DATA}"
+
+setup-choose-arena: "&aEscoge tu arena primero."
+
+settings-arena-1: "Configuración de la arena {ARENA_NAME}"
+settings-arena-2: "Configurar Aparición de Arena"
+settings-arena-3: "Configurar Aparición de Espectador"
+settings-arena-4: "Configurar Comportamiento de Arena"
+settings-arena-5: "Asignar Comportamiento de Señal de Entrada"
+settings-arena-6: "Asignar Ubicación de Señal de Entrada"
+settings-arena-7: "Configurar Marcador"
+settings-arena-8: "Editar este mundo"
+settings-arena-9: "&cBorrar esta arena"
+
+behaviour-setup-1: "Configuración de la arena"
+behaviour-setup-2: "&eActivar la arena?"
+behaviour-setup-3: "&eAsignar Temporizador de Invencibilidad"
+behaviour-setup-4: "&eActivar Modo Espectador?"
+behaviour-setup-5: "&eActicar Modo de Equipos?"
+behaviour-setup-6: "&eEmpezar cuando esté lleno?"
+
+team-setup-1: 'Configurar modo de equipos'
+team-setup-2: 'Jugadores por equipo'
+team-setup-3: 'Equipos mínimos'
+team-setup-4: 'Equipos máximos'
+team-setup-5: 'Colores de equipo'
+
+team-error-1: '&cError de configuración de equipo, debe ser un número entero de rango 0-15 y separado por `;`'
+team-error-2: '&cEl/Los color(es) de equipo configurado(s) es/son menor(es) que los equipos máximos.'
+
+solo-setup-1: "Configuración de equipo solitario"
+solo-setup-2: "Jugadores mínimos"
+solo-setup-3: "Jugadores máximos"
+
+behaviour-setup-complete: "&aArena &e{ARENA_NAME} actualizada exitosamente"
+
+behaviour-sign-1: "&eConfiguración de Comportamiento del Formulario"
+behaviour-sign-2: "&aBienvenido a la configuración de comportamiento del letrero. Antes de hacer cualquier cosa, puede que necesites saber esto"
+behaviour-sign-3: "&eLíneas de estado\n&a &b &c = puedes utilizar color con &\n%alive = cantidad de jugadores en juego\n%dead = cantidad de jugadores muertos\n%status = estado del juego\n%world = nombre del mundo de la arena\n%max = jugadores máximos por arena"
+behaviour-sign-4: "&aLetrero de Referencia 1"
+behaviour-sign-5: "&aLetrero de Referencia 2"
+behaviour-sign-6: "&aLetrero de Referencia 3"
+behaviour-sign-7: "&aLetrero de Referencia 4"
+behaviour-sign-complete: "&aLíneas de letrero de &e{ARENA_NAME} actualizadas exitosamente"
+
+setup-arena-spawn: "Ahora puedes configurar las posiciones de aparición de la arena, usa la vara de fuego y rompe un bloque para asignar la posición, cambios hechos en este mundo serán descartados."
+setup-arena-spectator: "Ahora puedes configurar la posición del espectador de la arena, usa la vara de fuego y rompe un bloque para asignar la posición, cambios hechos en este mundo serán descartados."
+setup-arena-joinsign: "Ahora puedes configurar la posición del letrero, usa la vara de fuego y rompe un bloque para asignar la posición."
+setup-npc: "Ahora puedes configurar la posición del NPC, usa la vara de fuego y rompe un bloque para asignar la posición."
+edit-world: "Ahora puedes editar este mundo, cualquier cambio será guardado."
+
+arena-delete-1: "&cBorrar"
+arena-delete-2: "Cancelar"
+arena-delete-confirm: "&cEstás seguro que quieres hacer esto? Borrar una arena borrará tu configuración y tu mundo!"
+
+setup-scoreboard: ""
+
+spectator-select1: "Selecciona el Nombre de Jugador"
+spectator-select2: "Selecciona un jugador para espectar"
+spectator-exit: "&cSalir"
+spectator-not-ingame: "&cYa no estás en la arena."
+spectator-player-left: "&cEse jugador ya no está en la arena."
+
+setup-arena-1: "&5Configuración de SkyWars."
+setup-arena-2: "&6El nombre de tu Arena"
+setup-arena-3: "&6Selecciona el nivel de tu Arena"
+setup-arena-4: "&eJugadores máximos"
+setup-arena-5: "&eJugadores mínimos"
+setup-arena-6: "&7Modo de espectador"
+setup-arena-7: "&7Empezar cuando esté lleno"
+
+setup-arena-spawn-1: "Configurar aparición?"
+setup-arena-spawn-2: "&aPuede que necesites asignar la posición de aparición de arena para que el sistema la pueda habilitar más rápido."
+setup-arena-spawn-3: "Configurar aparición de arena"
+setup-arena-spawn-4: "&cConfigurar después"
+
+setup-later: "&aPuedes configurar esto después con /sw settings"
+
+no-data: "&cEste jugador no existe en las bases de datos!"
+
+form-error-1: 'La ID que pediste es inválida, incapaz de ejecutar este comando.'
+
+scoreboard-button-1: "Esperando vista"
+scoreboard-button-2: "Vista en juego"
+scoreboard-button-3: "Vista de final del juego"
+scoreboard-button-4: "Vista de espectador"
+scoreboard-button-5: "Salir"
+
+scoreboard-state-1: "Esta sección será usada durante estado de espera."
+scoreboard-state-2: "Esta sección será usada cuando la arena haya empezado sin equipos."
+scoreboard-state-3: "Esta sección será usada cuando el juego haya terminado."
+scoreboard-state-4: "Esta sección será usada cuando el jugador haya muerto."
+
+scoreboard-success: "&aConfigurada exitosamente la configuración del marcador de arena."
+
+kit-selection-1: "Selecciona tu kit."
+kit-selection-2: "Select uno de los kits abajo."
+
+kit-removed: "%prefix&cQuitaste tu kit actual"
+kit-selected: "%prefix&aHas seleccionado el kit &e{KIT_NAME}&a!"
+
+kit-no-permission: "%prefix&cNo tienes permiso de seleccionar el kit &e{KIT_NAME}&c!"
+
+# Kill message
+death-message-void: "&7- &e{PLAYER} &cfue matado/a por el vacío."
+death-message-suicide: "&7- &e{PLAYER} &cse suicidó."
+death-message-suffocated: "&7- &e{PLAYER} &cfue sofocado/a hasta la muerte."
+death-message-burned: "&7- &e{PLAYER} &cfue quemado/a hasta la muerte."
+death-message-catused: "&7- &e{PLAYER} &cmurió por un cactus. Tonto?"
+death-message-fall: "&7- &e{PLAYER} &ccayó por el cielo."
+death-message-toasted: "&7- &e{PLAYER} &cfue tostado/a por agua"
+death-message-drowned: "&7- &e{PLAYER} &cfue ahogado/a"
+death-message-nature: "&7- &e{PLAYER} &cfue matado/a por la naturaleza"
+death-message-explode: "&7- &e{PLAYER} &cexplotó en piezas"
+death-message-magic: "&7- &e{PLAYER} &cmurió por algún tipo de magia"
+death-message-unknown: "&7- &e{PLAYER} es un miembro del Illuminati"
+death-message: "&7- &e{PLAYER} &cfue matado/a por &e{KILLER}"
+
+# Command help message
+help-main: "&cPor favor usa /sw help para la lista de comandos"
+lobby-help: "&2/sw leave &l&5»&r&f Teleportarse al lobby."
+random-help: "&2/sw random &l&5»&r&f Teleportarse aleatoriamente a una arena."
+stats-help: "&2/sw stats &l&5»&r&f Mostrar tu estado de juego."
+reload-help: "&2/sw reload &l&5»&r&f Volver a cargar el plugin, hacer un nuevo comienzo."
+create-help: "&2/sw create &l&5»&r&f Crear una nueva arena."
+cage-help: "&2/sw cage &l&5»&r&f Asignar tus jaulas personalizadas."
+join-help: "&2/sw join &b[Nombre de Arena] &l&5»&r&f Unirse a la arena."
+settings-help: "&2/sw settings &l&5»&r&f Configurar o modificar la arena."
+setlobby-help: "&2/sw setlobby &l&5»&r&f Asignar el lobby principal para el plugin."
+about-help: "&2/sw about &l&5»&r&f Acerca de y notas del autor."
+npc-help: "&2/sw npc &l&5»&r&f Crear un NPC para TopWinners."
+list-help: "&2/sw list &l&5»&r&f Mostrar todas las arenas activas en el servidor."
+
+# Command false usage help message
+start-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
+stop-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
+join-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
+moderation-usage: "&Uso: &2/sw moderation &b[On/Off]"
+
+setup-wrong-world-1: "&cNo estás en el mundo de arena correcto, teletranspórtate de vuelta al nivel {ARENA_WORLD}"
+setup-wrong-world-2: "&cNo puedes hacer esta acción en el mundo de la arena!"
+world-teleport: "&aTeleportándote de vuelta al mundo principal."
+
+cage-selection-1: "§8Formulario de selección de jaulas."
+cage-selection-2: "§aVariedades de jaulas disponibles!"
+
+cage-selected: "§8{CAGE_NAME}\n§aJaula seleccionada"
+cage-buy: "§8{CAGE_NAME}\n§a[Precio ${CAGE_PRICE}]"
+cage-bought: "§8{CAGE_NAME}\n§aJaula Comprada"
+cage-select: "§8{CAGE_NAME}\n§aSelecciona Jaula"
+
+cage-error-chosen: "&cYa has comprado esta jaula!"
+cage-chosen: "%prefix&aHas escogido la jaula &e{CAGE_NAME}."
+
+economy-error: "&cEsta función está deshabilitada ya que no hay un plugin de EconomyAPI instalado."
+economy-no-money: "&cNo tienes suficiente dinero para comprar esto."
+economy-internal: "&cIncapaz de procesar el pago, intenta de nuevo después."
+
+# Panel messages
+panel-cancelled: "&cTu pedido ha sido cancelado."
+panel-choose-cage: "&aHas escogido la jaula, &d{CAGE}"
+panel-join-spect: "&aUbicación de aparición de espectador ha sido marcada."
+panel-join-sign: "&aUbicación del letrero de entrada ha sido marcada."
+panel-spawn-pos: "&aUbicación de aparición &e#{COUNT} marcada."
+panel-spawn-set: "&eLas ubicaciones de aparición han sido marcadas exitosamente."
+
+# Top winners
+top-winner-1: "&r&lGanador #{VAL}"
+top-winner-2: "&r&2{PLAYER}"
+top-winner-3: "&r&7{WINS} Victorias"


### PR DESCRIPTION
I've added standardized Spanish support on an `es_ES.yml` file (name can be associated to Spanish (Spain), but it's a standardized Spanish). 
Furthermore, I've modified some lines in the en_US locale to fit a more uniform styling and correct spelling/grammar mistakes.

Even when I thought everything well enough, the Spanish locale is prone to errors, so if somebody who knows Spanish would like to point any mistake out I would be glad, otherwise it should be ready for merging.

uw