### PR TITLE
Typo Fixing and Permissions

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -56,3 +56,6 @@ permissions:
       sw.command.cage:
         description: Allow players to access kit selection form.
         default: true
+      sw.command.stats:
+        description: Check SkyWars stats of players.
+        default: true

--- a/resources/language/en_US.yml
+++ b/resources/language/en_US.yml
@@ -193,7 +193,7 @@ list-help: "&2/sw list &l&5»&r&f List all running arenas in the server."
 # Command false usage help message
 start-usage: "&6Usage: &2/sw start &b[Arena Name]."
 stop-usage: "&6Usage: &2/sw start &b[Arena Name]."
-join-usage: "&6Usage: &2/sw start &b[Arena Name]."
+join-usage: "&6Usage: &2/sw join &b[Arena Name]."
 moderation-usage: "&6Usage: &2/sw moderation &b[On/Off]"
 
 setup-wrong-world-1: "&cYou are not in the right arena world, teleport back to level {ARENA_WORLD}"

--- a/resources/language/es_ES.yml
+++ b/resources/language/es_ES.yml
@@ -193,7 +193,7 @@ list-help: "&2/sw list &l&5»&r&f Mostrar todas las arenas activas en el servido
 # Command false usage help message
 start-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
 stop-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
-join-usage: "&Uso: &2/sw start &b[Nombre de Arena]."
+join-usage: "&Uso: &2/sw join &b[Nombre de Arena]."
 moderation-usage: "&Uso: &2/sw moderation &b[On/Off]"
 
 setup-wrong-world-1: "&cNo estás en el mundo de arena correcto, teletranspórtate de vuelta al nivel {ARENA_WORLD}"

--- a/resources/language/ko_KR.yml
+++ b/resources/language/ko_KR.yml
@@ -193,7 +193,7 @@ list-help: "&2/sw list &l&5»&r&f 서버에서 실행되고 있는 게임 목록
 # Command false usage help message
 start-usage: "&6사용법: &2/sw start &b[게임 이름]."
 stop-usage: "&6사용법: &2/sw start &b[게임 이름]."
-join-usage: "&6사용법: &2/sw start &b[게임 이름]."
+join-usage: "&6사용법: &2/sw join &b[게임 이름]."
 moderation-usage: "&6사용법: &2/sw moderation &b[On/Off]"
 
 setup-wrong-world-1: "&c당신은 올바른 월드에 있지 않습니다. {ARENA_WORLD} 월드로 돌아갑니다."

--- a/resources/language/pt_BR.yml
+++ b/resources/language/pt_BR.yml
@@ -193,7 +193,7 @@ list-help: "&2/sw list &l&5»&r&f Lista todas as arenas em execução no servido
 # Command false usage help message
 start-usage: "&6Use: &2/sw start &b[Nome da arena]."
 stop-usage: "&6Use: &2/sw start &b[Nome da arena]."
-join-usage: "&6Use: &2/sw start &b[Nome da arena]."
+join-usage: "&6Use: &2/sw join &b[Nome da arena]."
 moderation-usage: "&6Use: &2/sw moderation &b[On/Off]"
 
 setup-wrong-world-1: "&cVocê não está na arena certa, teleporte-se de volta ao mundo {ARENA_WORLD}"

--- a/resources/language/ru_RU.yml
+++ b/resources/language/ru_RU.yml
@@ -193,7 +193,7 @@ list-help: "&2/sw list &l&5»&r&f Показать список всех зап�
 # Command false usage help message
 start-usage: "&6Использовать: &2/sw start &b[Arena Name]!"
 stop-usage: "&6Использовать: &2/sw start &b[Arena Name]!"
-join-usage: "&6Использовать: &2/sw start &b[Arena Name]!"
+join-usage: "&6Использовать: &2/sw join &b[Arena Name]!"
 moderation-usage: "&6Использовать: &2/sw moderation &b[On/Off]"
 
 setup-wrong-world-1: "&cВы находитесь не в том мире арены, телепортируйтесь обратно в мир {ARENA_WORLD}"


### PR DESCRIPTION
1. Changed join-usage help message.

2. 'sw.command.stats' permission was not existing in plugin.yml.